### PR TITLE
Fix #7: Add `idType` param to `useParticipantIds`

### DIFF
--- a/src/hooks/useParticipantIds.ts
+++ b/src/hooks/useParticipantIds.ts
@@ -34,6 +34,7 @@ type SortParticipants =
   | 'user_id'
   | 'user_name'
   | SortParticipantsFunction;
+type IdType = 'user' | 'session';
 
 const defaultFilter: FilterParticipants = Boolean;
 const defaultSort: SortParticipants = () => 0;
@@ -45,10 +46,11 @@ interface UseParticipantIdsArgs {
   onParticipantLeft?(ev: DailyEventObjectParticipantLeft): void;
   onParticipantUpdated?(ev: DailyEventObjectParticipant): void;
   sort?: SortParticipants;
+  idType?: IdType;
 }
 
 /**
- * Returns a list of participant ids (= session_id).
+ * Returns a list of participant ids (default = session_id).
  * The list can optionally be filtered and sorted, using the filter and sort options.
  */
 export const useParticipantIds = (
@@ -59,6 +61,7 @@ export const useParticipantIds = (
     onParticipantLeft,
     onParticipantUpdated,
     sort = defaultSort,
+    idType = 'session',
   }: UseParticipantIdsArgs = {
     filter: defaultFilter,
     sort: defaultSort,
@@ -121,13 +124,14 @@ export const useParticipantIds = (
     return sortFn;
   }, [sort]);
 
+  const idKey = idType === 'user' ? 'user_id' : 'session_id';
   const sortedIds = useMemo(() => {
     return allParticipants
       .filter(filterFn)
       .sort(sortFn)
-      .map((p) => p.session_id)
+      .map((p) => p[idKey])
       .filter(Boolean);
-  }, [allParticipants, filterFn, sortFn]);
+  }, [allParticipants, filterFn, sortFn, idKey]);
 
   useThrottledDailyEvent(
     [


### PR DESCRIPTION
See #7 for discussion.