### PR TITLE
Improve useAudioLevel parameter types

### DIFF
--- a/src/hooks/useAudioLevel.ts
+++ b/src/hooks/useAudioLevel.ts
@@ -7,7 +7,7 @@ import { inlineAudioWorklet } from '../lib/inlineAudioWorklet';
  * @param onVolumeChange The function to execute when the volume changes. Can be used to visualise audio output.
  */
 export const useAudioLevel = (
-  mediaTrack: MediaStreamTrack,
+  mediaTrack: MediaStreamTrack | undefined,
   onVolumeChange: (volume: number) => void
 ) => {
   const audioCtx = useRef<AudioContext>();


### PR DESCRIPTION
While implementing something with the `useAudioLevel`-hook, I noticed that the types could possibly be improved.

If using the example at https://docs.daily.co/reference/daily-react/use-audio-level, it gives you an error, because `audioTrack?.persistentTrack` can be undefined. That also applies when passing it something like `callParticipant?.tracks.audio.track`.

When inspecting the related code, i noticed that there is an early check for the existence of `mediaTrack` which led me to believe that the original idea has been to have this parameter as possible `undefined`.