### PR TITLE
Type narrowing on `useDailyEvent` and `useThrottledDailyEvent`

### DIFF
--- a/src/hooks/useDailyEvent.ts
+++ b/src/hooks/useDailyEvent.ts
@@ -18,7 +18,7 @@ export const getUnique = () => uniqueCounter++;
  * @param ev The DailyEvent to register.
  * @param callback A memoized callback reference to run when the event is emitted.
  */
-export const useDailyEvent<T extends DailyEvent> = (ev: T, callback: EventCallback<T>) => {
+export const useDailyEvent = <T extends DailyEvent>(ev: T, callback: EventCallback<T>) => {
   const { off, on } = useContext(DailyEventContext);
   const [isBlocked, setIsBlocked] = useState(false);
   const reassignCount = useRef<number>(0);

--- a/src/hooks/useDailyEvent.ts
+++ b/src/hooks/useDailyEvent.ts
@@ -3,7 +3,7 @@ import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { DailyEventContext } from '../DailyEventContext';
 
-type EventCallback = (event?: DailyEventObject) => void;
+type EventCallback<T extends DailyEvent> = (event?: DailyEventObject<T>) => void;
 
 let uniqueCounter = 0;
 export const getUnique = () => uniqueCounter++;
@@ -18,7 +18,7 @@ export const getUnique = () => uniqueCounter++;
  * @param ev The DailyEvent to register.
  * @param callback A memoized callback reference to run when the event is emitted.
  */
-export const useDailyEvent = (ev: DailyEvent, callback: EventCallback) => {
+export const useDailyEvent<T extends DailyEvent> = (ev: T, callback: EventCallback<T>) => {
   const { off, on } = useContext(DailyEventContext);
   const [isBlocked, setIsBlocked] = useState(false);
   const reassignCount = useRef<number>(0);

--- a/src/hooks/useThrottledDailyEvent.ts
+++ b/src/hooks/useThrottledDailyEvent.ts
@@ -5,7 +5,9 @@ import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { DailyEventContext } from '../DailyEventContext';
 import { getUnique, useDailyEvent } from './useDailyEvent';
 
-type EventCallback = (events: DailyEventObject[]) => void;
+type EventCallback<T extends DailyEvent[]> = (
+  events: { [Index in keyof T]: DailyEventObject<T[Index]> }[number]
+) => void;
 
 /**
  * Sets up a throttled daily event listener using [on](https://docs.daily.co/reference/daily-js/instance-methods/on) method.
@@ -20,9 +22,9 @@ type EventCallback = (events: DailyEventObject[]) => void;
  * @param callback A memoized callback reference to run when throttled events are emitted.
  * @param throttleTimeout The minimum waiting time until the callback is called again. Default: 100
  */
-export const useThrottledDailyEvent = (
-  ev: DailyEvent | DailyEvent[],
-  callback: EventCallback,
+export const useThrottledDailyEvent = <T extends DailyEvent>(
+  ev: T | T[],
+  callback: EventCallback<T extends DailyEvent ? [T] : T>,
   throttleTimeout = 100
 ) => {
   const { off, on } = useContext(DailyEventContext);


### PR DESCRIPTION
Allow `useDailyEvent` and `useThrottledDailyEvent` to do type narrowing for the callback.

Before:
```ts
useDailyEvent(
    'camera-error', 
    // `event` is typed as `any`, type narrowing has to be done by the user
    useCallback((event) => {...}, []
);

useThrottledDailyEvent(
    ['camera-error', 'error'], 
    // `event` is typed as `any`, type narrowing has to be done by the user
    useCallback((event) => {...}, []
);
```

After:
```ts
useDaily(
    'camera-error', 
    // `event` is typed as `DailyEventObjectCameraError `, the type is correctly derived from the event name
    useCallback((event) => {...}, []
);

useThrottledDailyEvent(
    ['camera-error', 'error'],
    // `event` is typed as `DailyEventObjectCameraError | DailyEventObjectFatalError`, the type is correctly derived from the event name
    useCallback((event) => {...}, []
);
```