### PR TITLE
fix(util): add a circular reference check for `getPaths`

### DIFF
--- a/src/utils/getParticipantPaths.ts
+++ b/src/utils/getParticipantPaths.ts
@@ -4,18 +4,26 @@ import { Paths } from '../types/paths';
 /**
  * Returns all property paths for an object.
  */
-const getPaths = (o: Record<any, any>, currentPath = ''): string[] => {
+const getPaths = (o: Record<any, any>, currentPath = '', visited = new Set()): string[] => {
   if (typeof o !== 'object' || o === null) {
     return [currentPath];
   }
+
+  if (visited.has(o)) {
+    return [currentPath];
+  }
+
+  visited.add(o);
 
   const paths = [];
   for (const key in o) {
     if (Object.prototype.hasOwnProperty.call(o, key)) {
       const newPath = currentPath ? `${currentPath}.${key}` : key;
-      paths.push(newPath, ...getPaths(o[key], newPath));
+      paths.push(newPath, ...getPaths(o[key], newPath, visited));
     }
   }
+
+  visited.delete(o);
 
   return paths;
 };


### PR DESCRIPTION
Fixes https://github.com/daily-co/daily-react/issues/33

Tagging @Regaddi and @mattieruth for review :)

<!-- If you're experiencing a bug while on a Daily call, before filing a bug report, please try these troubleshooting steps: https://help.daily.co/en/articles/2303117-top-troubleshooting-tips -->

# Expected behavior

- getParticipantPaths should not infinitely recurse

<!-- Please share a clear and concise description of what you expected to happen. -->

# Describe the bug (unexpected behavior)

When using React in an Angular controlled application, global objects are monkey-patched with 'zone-aware' properties that Angular uses for change detection. This extends to objects like `MediaStreamTrack`.

`getParticipantPaths` uses a circular-reference unaware check to get nested paths, so it errors out as the zone properties are  infinitely referencing themselves.

**The solution is to make getParticipantPaths aware of circular references and not cause a max call stack error**

<!-- A clear and concise description of what the bug is. -->

# Steps to reproduce

1. Run Daily SDK in an Angular app that has react components mounted
2. Create a call
3. Someone joins the call
4. See maximum call stack exceeded

<!-- 1. Go to '...' -->
<!-- 2. Click on '....' -->
<!-- 3. Scroll down to '....' -->
<!-- 4. See error -->

# Screenshots

![image](https://github.com/daily-co/daily-react/assets/1136276/77d10b8d-2a34-4e8e-a2ef-88bbe67aab22)
> Image of the debugger catching the beginning of the infinite recursion

![image](https://github.com/daily-co/daily-react/assets/1136276/055cd632-1963-4d11-9a87-dce5f49b8fe1)
> Minified error from the getPaths function when a user joins the call

<!-- If applicable, add screenshots to help explain your problem. -->
