### PR TITLE
Add Jotai to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "peerDependencies": {
     "@daily-co/daily-js": ">=0.68.0 <1",
-    "react": ">=16.13.1"
+    "react": ">=16.13.1",
+    "jotai":">=2.9.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
[This commit](https://github.com/daily-co/daily-react/commit/550f45bc30fb144e5d842ce7da7ac194c24a7328#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) dealt with removing Recoil and replacing it with Jotai.  Recoil was removed as a peer dependency but Jotai was not added.

This PR serves to add Jotai as a peer dependency.

If you me to open an issue that this PR resolves, I can do that as well.