### PR TITLE
Fix: Preserve device selection when getInputDevices returns empty objects

### DIFF
--- a/src/DailyDevices.tsx
+++ b/src/DailyDevices.tsx
@@ -91,13 +91,24 @@ export const DailyDevices: React.FC<React.PropsWithChildren<unknown>> = ({
             device: {} | MediaDeviceInfo,
             d: MediaDeviceInfo,
             prevDevices: StatefulDevice[]
-          ) => ({
-            device: d,
-            selected: 'deviceId' in device && d.deviceId === device.deviceId,
-            state:
-              prevDevices.find((p) => p.device.deviceId === d.deviceId)
-                ?.state ?? 'granted',
-          });
+          ) => {
+            const prevDevice = prevDevices.find(
+              (p) => p.device.deviceId === d.deviceId
+            );
+            // Determine if this device is selected
+            // First, check if getInputDevices() returned a valid deviceId
+            const isSelectedByDeviceId =
+              'deviceId' in device && d.deviceId === device.deviceId;
+            // If getInputDevices() returned an empty object, preserve the previous selection
+            const isSelectedByPrevious =
+              !('deviceId' in device) && prevDevice?.selected;
+
+            return {
+              device: d,
+              selected: isSelectedByDeviceId || Boolean(isSelectedByPrevious),
+              state: prevDevice?.state ?? 'granted',
+            };
+          };
           const sortDeviceByLabel = (a: StatefulDevice, b: StatefulDevice) => {
             if (a.device.deviceId === 'default') return -1;
             if (b.device.deviceId === 'default') return 1;


### PR DESCRIPTION
## Problem
This PR fixes an issue where `currentMic`, `currentCam`, and `currentSpeaker` from `useDevices()` become `undefined` after joining a call, despite:
- `micState` remaining "granted"
- Audio/video tracks working correctly
- The device being properly selected before joining

## Root Cause
The bug was in the `mapDevice` function in `DailyDevices.tsx`. When `daily.getInputDevices()` returns empty objects (which can happen during race conditions or timing issues immediately after joining a call), the condition:
```typescript
selected: 'deviceId' in device && d.deviceId === device.deviceId
```
evaluates to `false` for all devices, resulting in no device being marked as selected.

## Solution
Modified the `mapDevice` function to preserve the previous device selection when `getInputDevices()` returns empty objects:
- If `getInputDevices()` returns valid device info → uses it (normal behavior)
- If `getInputDevices()` returns empty objects → preserves previous selection (fixes the bug)

## Changes
- Modified `mapDevice` function in `src/DailyDevices.tsx` to check and preserve previous selection state
- Maintains backward compatibility with existing functionality
- Ensures stable device state throughout the call lifecycle

## Testing
This fix addresses the specific scenario where device selection is lost after joining a call. The change is backward compatible and preserves existing behavior when `getInputDevices()` returns valid data.